### PR TITLE
Handle files in the staging area

### DIFF
--- a/src/nxstacker/io/ptycho/ptypy.py
+++ b/src/nxstacker/io/ptycho/ptypy.py
@@ -6,7 +6,7 @@ import h5py
 import numpy as np
 
 from nxstacker.io.projection import ProjectionFile
-from nxstacker.utils.io import top_level_dir
+from nxstacker.utils.io import is_staging_area, top_level_dir
 from nxstacker.utils.model import (
     FilePath,
     FixedValue,
@@ -152,12 +152,22 @@ class PtyPyFile(ProjectionFile):
 
     def _overwrite_raw_dir(self):
         """Overwrite the _raw_dir attribute."""
-        raw_dir = top_level_dir(self._raw_file)
+        if is_staging_area(self._raw_file):
+            depth = 8
+        else:
+            depth = 6
+
+        raw_dir = top_level_dir(self._raw_file, depth=depth)
 
         if Path(raw_dir).is_dir():
             self._raw_dir = raw_dir
         else:
-            self._raw_dir = top_level_dir(self._file_path)
+            # this is a fallback
+            if is_staging_area(self._file_path):
+                depth = 8
+            else:
+                depth = 6
+            self._raw_dir = top_level_dir(self._file_path, depth=depth)
 
     def object_complex(self, mode=0):
         """Return the complex object of a particular mode.

--- a/src/nxstacker/io/ptycho/ptyrex.py
+++ b/src/nxstacker/io/ptycho/ptyrex.py
@@ -6,7 +6,7 @@ import h5py
 import numpy as np
 
 from nxstacker.io.projection import ProjectionFile
-from nxstacker.utils.io import top_level_dir
+from nxstacker.utils.io import is_staging_area, top_level_dir
 from nxstacker.utils.model import (
     FixedValue,
 )
@@ -134,12 +134,22 @@ class PtyREXFile(ProjectionFile):
         if isinstance(save_dir, bytes):
             save_dir = save_dir.decode()
 
-        raw_dir = top_level_dir(save_dir)
+        if is_staging_area(save_dir):
+            depth = 8
+        else:
+            depth = 6
+
+        raw_dir = top_level_dir(save_dir, depth=depth)
 
         if Path(raw_dir).is_dir():
             self._raw_dir = raw_dir
         else:
-            self._raw_dir = top_level_dir(self._file_path)
+            # this is a fallback
+            if is_staging_area(self._file_path):
+                depth = 8
+            else:
+                depth = 6
+            self._raw_dir = top_level_dir(self._file_path, depth=depth)
 
     def _pad_extent(self, img, pad_value=0):
         """Return the extent of padding for PtyREX file."""

--- a/src/nxstacker/io/xrf/python_processing.py
+++ b/src/nxstacker/io/xrf/python_processing.py
@@ -4,7 +4,7 @@ from types import MappingProxyType
 import h5py
 
 from nxstacker.io.projection import ProjectionFile
-from nxstacker.utils.io import top_level_dir
+from nxstacker.utils.io import is_staging_area, top_level_dir
 
 
 class XRFWindowFile(ProjectionFile):
@@ -102,7 +102,12 @@ class XRFWindowFile(ProjectionFile):
 
     def _overwrite_raw_dir(self):
         """Overwrite the _raw_dir attribute."""
-        self._raw_dir = top_level_dir(self._file_path)
+        if is_staging_area(self._file_path):
+            depth = 8
+        else:
+            depth = 6
+
+        self._raw_dir = top_level_dir(self._file_path, depth=depth)
 
     def elemental_map(self, transition):
         """Return the correpsonding elemental map.

--- a/src/nxstacker/utils/io.py
+++ b/src/nxstacker/utils/io.py
@@ -154,3 +154,26 @@ def get_version():
     except PackageNotFoundError:
         ver = "dev"
     return ver
+
+
+def is_staging_area(directory):
+    """Check if the given directory is a DLS staging area.
+
+    Parameters
+    ----------
+    directory : str or pathlib.Path
+        the directory to be checked
+
+    Returns
+    -------
+    True or False, indicating whether this is a DLS staging area
+
+    """
+    dir_ = Path(directory).resolve()
+
+    try:
+        dir_.relative_to("/dls/staging")
+    except ValueError:
+        return False
+    else:
+        return True

--- a/src/nxstacker/utils/io.py
+++ b/src/nxstacker/utils/io.py
@@ -33,8 +33,8 @@ def file_has_paths(file_path, paths):
 def top_level_dir(directory, depth=6):
     """Return partial path of a directory with a specific depth.
 
-    E.g. "/first/second/third/fourth" with a depth of 2 will return
-    "/first/second".
+    E.g. "/first/second/third/fourth" with a depth of 3 will return
+    "/first/second" ('/' counts as one depth).
 
     Parameters
     ----------

--- a/src/nxstacker/utils/parse.py
+++ b/src/nxstacker/utils/parse.py
@@ -145,8 +145,9 @@ def as_dls_staging_area(visit):
     -------
     the corresponding staging area for a visit, e.g. if the visit is
     "/dls/xxx/data/2024" then it will return
-    "/dls/staging/xxx/data/2024". It will return the original path if
-    the visit is not a DLS visit (not starting as "/dls").
+    "/dls/staging/dls/xxx/data/2024". It will return the original path
+    if the visit is not a DLS visit (not starting as "/dls") or already
+    a staging area for a visit.
 
     """
     visit = Path(visit).resolve()

--- a/src/nxstacker/utils/parse.py
+++ b/src/nxstacker/utils/parse.py
@@ -157,5 +157,12 @@ def as_dls_staging_area(visit):
     except ValueError:
         return visit
     else:
-        staging = Path.joinpath(Path("/dls/staging"), without_dls)
-        return staging
+        try:
+            visit.relative_to("/dls/staging")
+        except ValueError:
+            # not a staging, return its staging version
+            staging = Path.joinpath(Path("/dls/staging/dls"), without_dls)
+            return staging
+        else:
+            # it is a staging, just return it
+            return visit

--- a/src/tests/utils/test_io.py
+++ b/src/tests/utils/test_io.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+from nxstacker.utils.io import is_staging_area, top_level_dir
+
+
+class TestTopLevelDir:
+    def test_default_depth(self):
+        input_dir = Path("/dls/i99/data/2047/cm12345-1/raw/nexus/")
+
+        assert top_level_dir(input_dir) == Path(
+            "/dls/i99/data/2047/cm12345-1/"
+        )
+
+    def test_depth_for_staging(self):
+        input_dir = Path("/dls/staging/dls/i99/data/2047/cm12345-1/raw/nexus/")
+
+        assert top_level_dir(input_dir, depth=8) == Path(
+            "/dls/staging/dls/i99/data/2047/cm12345-1/"
+        )
+
+
+class TestIsStagingArea:
+    def test_is_staging(self):
+        input_dir = Path("/dls/staging/dls/i99/data/2047/cm12345-1")
+
+        assert is_staging_area(input_dir)
+
+    def test_not_staging(self):
+        input_dir = Path("/dls/i99/data/2047/cm12345-1")
+
+        assert not is_staging_area(input_dir)
+
+    def test_not_staging_non_dls(self):
+        input_dir = Path("/abc/dls/staging/dls/i99/data/2047/cm12345-1")
+
+        assert not is_staging_area(input_dir)

--- a/src/tests/utils/test_parse.py
+++ b/src/tests/utils/test_parse.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from nxstacker.utils.parse import as_dls_staging_area
+
+
+class TestAsDLSStagingArea:
+    def test_dls_standard(self):
+        input_dir = Path("/dls/i99/data/2047/cm12345-6")
+        # if the argument is an absolute path, the previous path is
+        # ignored
+        staging_dir = Path("/dls/staging") / str(input_dir)[1:]
+
+        assert as_dls_staging_area(input_dir) == staging_dir
+
+    def test_non_dls(self):
+        input_dir = Path("/tmp/i99/data/2047/cm12345-6")  # noqa: S108
+
+        assert as_dls_staging_area(input_dir) == input_dir
+
+    def test_already_staging(self):
+        input_dir = Path("/dls/staging/dls/i99/data/2047/cm12345-6")
+
+        assert as_dls_staging_area(input_dir) == input_dir


### PR DESCRIPTION
Fix #2.

This PR handles files when they are in the staging area. Previously `top_level_dir` assumes the directory of the projection files is not a staging area, so it uses the default `depth` to return the raw data directory, but the `depth` needs to be adjusted to `8` for a staging area to return the correct path.

A function `is_staging_area` is added to adjust the `depth` accordingly.

Small fixes in docs string and tests for `top_level_dir`, `is_staging_area` and `as_dls_staging_area` are also added.