### PR TITLE
Speed up the finding of projection files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,8 +27,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install .
-        python -m pip install ruff
+        python -m pip install --disable-pip-version-check .
+        python -m pip install --disable-pip-version-check ruff
 
     - name: Lint with Ruff
       run: ruff check --output-format=github .

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -30,7 +30,7 @@ jobs:
         run: python -m pip install --upgrade pip
 
       - name: Install test dependencies
-        run: python -m pip install .[test]
+        run: python -m pip install --disable-pip-version-check .[test]
 
       - name: Run tests
         run: python -m pytest src/tests

--- a/src/nxstacker/experiment/ptychotomo.py
+++ b/src/nxstacker/experiment/ptychotomo.py
@@ -53,6 +53,7 @@ class PtychoTomo(TomoExpt):
         sort_by_angle=False,
         pad_to_max=True,
         compress=False,
+        skip_proj_file_check=True,
         **kwargs,
     ):
         """Initialise the instance.
@@ -100,6 +101,11 @@ class PtychoTomo(TomoExpt):
         compress : bool, optional
             whether to apply compression (Blosc) to the NXtomo file.
             Default to False.
+        skip_proj_file_check : bool, optional
+            whether to skip the file check when adding an hdf5 to the list
+            of projection files. Usually this is true when you are doing a
+            typical stacking and sure no other hdf5 files are present in
+            proj_dir. Default to True.
         kwargs : dict, optional
             options for ptycho-tomography
 
@@ -116,6 +122,7 @@ class PtychoTomo(TomoExpt):
             sort_by_angle=sort_by_angle,
             pad_to_max=pad_to_max,
             compress=compress,
+            skip_proj_file_check=skip_proj_file_check,
         )
 
         self._save_complex = kwargs.get("save_complex", False)

--- a/src/nxstacker/experiment/tomoexpt.py
+++ b/src/nxstacker/experiment/tomoexpt.py
@@ -38,6 +38,7 @@ class TomoExpt:
     proj_file = FilePath(undefined_ok=True)
     nxtomo_dir = Directory()
     raw_dir = Directory(undefined_ok=True, must_exist=True)
+    skip_proj_file_check = FixedValue()
     facility = ExperimentFacility()
     include_scan = IdentifierRange(int)
     include_proj = IdentifierRange(int)
@@ -65,12 +66,14 @@ class TomoExpt:
         sort_by_angle,
         pad_to_max,
         compress,
+        skip_proj_file_check,
     ):
         """Initialise a tomography experiment."""
         self.proj_dir = proj_dir
         self.proj_file = proj_file
         self.nxtomo_dir = nxtomo_dir
         self.raw_dir = raw_dir
+        self.skip_proj_file_check = skip_proj_file_check
 
         self.facility = facility
 

--- a/src/nxstacker/experiment/tomoexpt.py
+++ b/src/nxstacker/experiment/tomoexpt.py
@@ -316,6 +316,21 @@ class TomoExpt:
         logger.info(
             f"The directory to look for projections is '{self.proj_dir}'."
         )
+        if self.skip_proj_file_check:
+            logger.info(
+                "Skipping the validation of projection files in the above "
+                "directory."
+            )
+            if self.short_name == "ptycho":
+                assume_file_type = self.facility.ptycho_file_type[0]
+            elif self.short_name == "xrf":
+                assume_file_type = self.facility.xrf_file_type[0]
+            else:
+                assume_file_type = "'unknown'"
+            logger.info(
+                f"Assume the projection files are from {assume_file_type}."
+            )
+
         st = time.perf_counter()
         return st
 

--- a/src/nxstacker/experiment/xrftomo.py
+++ b/src/nxstacker/experiment/xrftomo.py
@@ -39,6 +39,7 @@ class XRFTomo(TomoExpt):
         sort_by_angle=False,
         pad_to_max=True,
         compress=False,
+        skip_proj_file_check=True,
         **kwargs,
     ):
         """Initialise the instance."""
@@ -54,6 +55,7 @@ class XRFTomo(TomoExpt):
             sort_by_angle=sort_by_angle,
             pad_to_max=pad_to_max,
             compress=compress,
+            skip_proj_file_check=skip_proj_file_check,
         )
 
         self.transition = kwargs.get("transition")

--- a/src/nxstacker/facility/specs/i08-1.yaml
+++ b/src/nxstacker/facility/specs/i08-1.yaml
@@ -1,3 +1,5 @@
+ptycho_file_type:
+  - PtyPy
 sample_name_path:
   - /entry/sample/name
 rotation_angle_path:

--- a/src/nxstacker/facility/specs/i13-1.yaml
+++ b/src/nxstacker/facility/specs/i13-1.yaml
@@ -1,3 +1,5 @@
+ptycho_file_type:
+  - PtyREX
 start_time_path:
   - /entry/instrument/NDAttributes/NDArrayTimeStamp #@position_0.h5
 end_time_path:

--- a/src/nxstacker/facility/specs/i14.yaml
+++ b/src/nxstacker/facility/specs/i14.yaml
@@ -1,3 +1,7 @@
+ptycho_file_type:
+  - PtyPy
+xrf_file_type:
+  - python processing
 detector_distance_path:
   - /entry/instrument/detectors/excalibur_z
   - /entry/instrument/scannables/excalibur_z/value

--- a/src/nxstacker/parser/parser.py
+++ b/src/nxstacker/parser/parser.py
@@ -25,6 +25,7 @@ HELP_EXCLUDE_ANGLE = "rotation angle(s) that should be excluded from"
 HELP_SORT_BY_ANGLE = "sort the projections by their rotation angles"
 HELP_PAD_TO_MAX = "pad projection to the maximum size of the stack"
 HELP_COMPRESS = "compress the NXtomo file"
+HELP_SKIP_PROJ_FILE_CHECK = "check if the projection file is valid"
 HELP_SAVE_COMPLEX = "save the complex result from ptychography"
 HELP_SAVE_MODULUS = "save the modulus result from ptychography"
 HELP_SAVE_PHASE = "save the phase result from ptychography"
@@ -109,6 +110,13 @@ def _parser_common():
     )
     parser.add_argument(
         "--compress", action="store_true", default=False, help=HELP_COMPRESS
+    )
+    parser.add_argument(
+        "--skip-check",
+        action="store_true",
+        default=True,
+        dest="skip_proj_file_check",
+        help=HELP_SKIP_PROJ_FILE_CHECK,
     )
 
     return parser

--- a/src/nxstacker/tomojoin.py
+++ b/src/nxstacker/tomojoin.py
@@ -33,6 +33,7 @@ def tomojoin(
     compress=False,
     quiet=False,
     dry_run=False,
+    skip_proj_file_check=True,
     **kwargs,
 ):
     """Combine projections to produce an NXtomo file.
@@ -100,6 +101,11 @@ def tomojoin(
         whether to suppress log message. Default to False.
     dry_run : bool, optional
         whether to perform a dry-run. Default to False.
+    skip_proj_file_check : bool, optional
+        whether to skip the file check when adding an hdf5 to the list
+        of projection files. Usually this is true when you are doing a
+        typical stacking and sure no other hdf5 files are present in
+        proj_dir. Default to True.
     kwargs : dict, optional
         options for ptycho-tomography
 
@@ -139,6 +145,7 @@ def tomojoin(
         sort_by_angle=sort_by_angle,
         pad_to_max=pad_to_max,
         compress=compress,
+        skip_proj_file_check=skip_proj_file_check,
         **kwargs,
     )
 

--- a/src/nxstacker/utils/experiment.py
+++ b/src/nxstacker/utils/experiment.py
@@ -17,6 +17,7 @@ def select_tomo_expt(
     sort_by_angle=False,
     pad_to_max=True,
     compress=False,
+    skip_proj_file_check=True,
     **kwargs,
 ):
     """Select the experiment for the projections.
@@ -63,6 +64,11 @@ def select_tomo_expt(
     compress : bool, optional
         whether to apply compression on the NXtomo file. Default to
         False.
+    skip_proj_file_check : bool, optional
+        whether to skip the file check when adding an hdf5 to the list
+        of projection files. Usually this is true when you are doing a
+        typical stacking and sure no other hdf5 files are present in
+        proj_dir. Default to True.
     kwargs : dict, optional
         optional arguments to different types of experiments
 
@@ -91,6 +97,7 @@ def select_tomo_expt(
                 sort_by_angle=sort_by_angle,
                 pad_to_max=pad_to_max,
                 compress=compress,
+                skip_proj_file_check=skip_proj_file_check,
                 **kwargs,
             )
         case "xrf":
@@ -106,6 +113,7 @@ def select_tomo_expt(
                 sort_by_angle=sort_by_angle,
                 pad_to_max=pad_to_max,
                 compress=compress,
+                skip_proj_file_check=skip_proj_file_check,
                 **kwargs,
             )
         case "dpc":


### PR DESCRIPTION
This PR speeds up the finding of projection files by adding a flag to skip projection file validation, which uses a preferred file type for different facilities.