### PR TITLE
Parallelise the stacking of projections in ptycho-tomo experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,13 +144,24 @@ transition must be present in the projection files.
 
 See [API](#api) for more information about the parameters.
 
+## Tip to speed up
+
+### Skip projection file validation
+
+You can set the parameter `skip_proj_file_check` to `True` to skip the
+validation of projection files if you know *all* the HDF5 files in `proj_dir`
+are from a particular source. The default is `False` for safety reason. Setting
+this to `True` can potentially speed up the time in finding the projection
+files, especially if you have a lot of HDF5 files there. The same can be
+achieved via the CLI by using `--skip-check`.
+
 ## API
 
 ### nxstacker.tomojoin
 
 #### `tomojoin`
 
-There are 20 parameters for this function, excluding parameters specific to a
+There are 21 parameters for this function, excluding parameters specific to a
 particular type of experiment.
 
 ##### Common parameters
@@ -254,6 +265,12 @@ whether to suppress log message. Default to False.
 - *dry_run*
 
 whether to perform a dry-run. Default to False.
+
+- *skip_proj_file_check*
+
+whether to skip the file check when adding an hdf5 to the list of projection
+files. Usually this is true when you are doing a typical stacking and sure no
+other hdf5 files are present in `proj_dir`. Default to False.
 
 ##### Specific to ptychography
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "nxstacker"
 version = "2024.5"
 dependencies = [
+  "blosc",
   "h5py",
   "hdf5plugin",
   "numpy",

--- a/src/nxstacker/experiment/ptychotomo.py
+++ b/src/nxstacker/experiment/ptychotomo.py
@@ -1,4 +1,3 @@
-import os
 from collections import deque
 from contextlib import nullcontext
 from multiprocessing import Pool
@@ -20,6 +19,7 @@ from nxstacker.utils.ptychography import (
     remove_phase_ramp,
     unwrap_phase,
 )
+from nxstacker.utils.resource import num_cpus
 
 
 class PtychoTomo(TomoExpt):
@@ -163,9 +163,7 @@ class PtychoTomo(TomoExpt):
         self._assume_file_order()
 
         if parallel:
-            # from py3.13 there is a os.process_cpu_count function
-            # can switch over once <=py3.12 support is dropped
-            ncpus = len(os.sched_getaffinity(0))
+            ncpus = num_cpus()
             with Pool(processes=ncpus) as pool:
                 for pty_file in pool.imap_unordered(
                     self._find_proj, file_iter

--- a/src/nxstacker/experiment/ptychotomo.py
+++ b/src/nxstacker/experiment/ptychotomo.py
@@ -13,6 +13,7 @@ from nxstacker.io.ptycho.ptyrex import PtyREXFile
 from nxstacker.utils.io import (
     file_has_paths,
     pad2stack,
+    save_proj_to_h5,
 )
 from nxstacker.utils.logger import create_logger
 from nxstacker.utils.model import FixedValue
@@ -567,6 +568,36 @@ class PtychoTomo(TomoExpt):
             nxtomo_phas = None
 
         return nxtomo_phas
+
+    def _save_cplx_to_file(self, k, f_cplx, complex_, angle_data):
+        if f_cplx and complex_ is not None:
+            cplx_data = {
+                "data": complex_,
+                "key": self.proj_dset_path,
+            }
+            save_proj_to_h5(
+                f_cplx, k, cplx_data, angle_data, self.compression_settings
+            )
+
+    def _save_modl_to_file(self, k, f_modl, modulus, angle_data):
+        if f_modl and modulus is not None:
+            modl_data = {
+                "data": modulus,
+                "key": self.proj_dset_path,
+            }
+            save_proj_to_h5(
+                f_modl, k, modl_data, angle_data, self.compression_settings
+            )
+
+    def _save_phas_to_file(self, k, f_phas, phase, angle_data):
+        if f_phas and phase is not None:
+            phas_data = {
+                "data": phase,
+                "key": self.proj_dset_path,
+            }
+            save_proj_to_h5(
+                f_phas, k, phas_data, angle_data, self.compression_settings
+            )
 
     def _read_cplx_modl_phas(
         self, k, pty_file, mode, read_cplx, read_modl, read_phas, queue

--- a/src/nxstacker/experiment/ptychotomo.py
+++ b/src/nxstacker/experiment/ptychotomo.py
@@ -59,7 +59,7 @@ class PtychoTomo(TomoExpt):
         sort_by_angle=False,
         pad_to_max=True,
         compress=False,
-        skip_proj_file_check=True,
+        skip_proj_file_check=False,
         **kwargs,
     ):
         """Initialise the instance.
@@ -111,7 +111,7 @@ class PtychoTomo(TomoExpt):
             whether to skip the file check when adding an hdf5 to the list
             of projection files. Usually this is true when you are doing a
             typical stacking and sure no other hdf5 files are present in
-            proj_dir. Default to True.
+            proj_dir. Default to False.
         kwargs : dict, optional
             options for ptycho-tomography
 
@@ -231,6 +231,7 @@ class PtychoTomo(TomoExpt):
 
     def _find_proj(self, fp):
         pty_file = None
+        to_include = False
         if h5py.is_hdf5(fp):
             if any([self._assume_ptypy_file, self._assume_ptyrex_file]):
                 # no check, quicker but less safe

--- a/src/nxstacker/experiment/ptychotomo.py
+++ b/src/nxstacker/experiment/ptychotomo.py
@@ -480,6 +480,25 @@ class PtychoTomo(TomoExpt):
 
         return (self.num_projections, *ob_sh)
 
+    def _create_cm(self, nxtomo_cplx, nxtomo_modl, nxtomo_phas):
+        cplx_cm = (
+            nullcontext()
+            if nxtomo_cplx is None
+            else h5py.File(nxtomo_cplx, "r+")
+        )
+        modl_cm = (
+            nullcontext()
+            if nxtomo_modl is None
+            else h5py.File(nxtomo_modl, "r+")
+        )
+        phas_cm = (
+            nullcontext()
+            if nxtomo_phas is None
+            else h5py.File(nxtomo_phas, "r+")
+        )
+
+        return cplx_cm, modl_cm, phas_cm
+
     def _nxtomo_cplx_minimal(self):
         if self._save_complex and all(
             pty_file.avail_complex for pty_file in self._projections

--- a/src/nxstacker/experiment/ptychotomo.py
+++ b/src/nxstacker/experiment/ptychotomo.py
@@ -135,7 +135,7 @@ class PtychoTomo(TomoExpt):
         self._unwrap_phase = kwargs.get("unwrap_phase", False)
         self._rescale = kwargs.get("rescale", False)
 
-    def find_all_projections(self, *, parallel=False):
+    def find_all_projections(self, *, parallel=True):
         """Find all projections.
 
         It goes through files and directories in self.proj_dir, add the

--- a/src/nxstacker/experiment/tomoexpt.py
+++ b/src/nxstacker/experiment/tomoexpt.py
@@ -245,31 +245,6 @@ class TomoExpt:
         rot_ang_dset = fh[self.rot_ang_dset_path]
         rot_ang_dset[proj_index] = angle
 
-    def _resize_proj(self, proj, stack_shape):
-        proj_y, proj_x = proj.shape
-        stack_y, stack_x = stack_shape[1:]
-
-        if self.pad_to_max and (proj_y < stack_y or proj_x < stack_x):
-            # pad to stack shape if the projection is smaller than
-            # others
-            y_diff = stack_y - proj_y
-            top = y_diff // 2
-            bottom = top + y_diff % 2
-
-            x_diff = stack_x - proj_x
-            left = x_diff // 2
-            right = left + x_diff % 2
-
-            final = np.pad(
-                proj,
-                ((top, bottom), (left, right)),
-                mode="symmetric",
-            )
-        else:
-            final = proj
-
-        return final
-
     def _gather_raw_dir_from_proj_file(self):
         if self.num_projections != 0:
             return list(dict.fromkeys(f.raw_dir for f in self.projections))

--- a/src/nxstacker/experiment/tomoexpt.py
+++ b/src/nxstacker/experiment/tomoexpt.py
@@ -86,6 +86,12 @@ class TomoExpt:
         self.pad_to_max = pad_to_max
         self.compress = compress
 
+        # define the instance holding the compression attributes
+        if self.compress:
+            self.compression_settings = CompressionBlosc()
+        else:
+            self.compression_settings = None
+
         self.projections = []
         self.stack_shape = ()
 
@@ -112,12 +118,6 @@ class TomoExpt:
         # no need to pass rotation_angle
         with suppress(KeyError):
             md_dict.pop("rotation_angle")
-
-        # define the instance holding the compression attributes
-        if self.compress:
-            self.compression_settings = CompressionBlosc()
-        else:
-            self.compression_settings = None
 
         create_minimal(
             filename,

--- a/src/nxstacker/experiment/tomoexpt.py
+++ b/src/nxstacker/experiment/tomoexpt.py
@@ -18,6 +18,7 @@ import numpy as np
 from nxstacker.io.nxtomo.minimal import LINK_DATA, LINK_ROT_ANG, create_minimal
 from nxstacker.utils.logger import create_logger
 from nxstacker.utils.model import (
+    CompressionBlosc,
     Directory,
     ExperimentFacility,
     FilePath,
@@ -49,6 +50,7 @@ class TomoExpt:
     sort_by_angle = FixedValue()
     pad_to_max = FixedValue()
     compress = FixedValue()
+    compression_settings = FixedValue()
     metadata = FixedValue()
     nxtomo_output_files = FixedValue()
     logger = FixedValue()
@@ -113,12 +115,18 @@ class TomoExpt:
         with suppress(KeyError):
             md_dict.pop("rotation_angle")
 
+        # define the instance holding the compression attributes
+        if self.compress:
+            self.compression_settings = CompressionBlosc()
+        else:
+            self.compression_settings = None
+
         create_minimal(
             filename,
             stack_shape,
             stack_dtype,
             self.facility,
-            compress=self.compress,
+            compression_settings=self.compression_settings,
             **md_dict,
         )
         return filename

--- a/src/nxstacker/experiment/tomoexpt.py
+++ b/src/nxstacker/experiment/tomoexpt.py
@@ -13,9 +13,6 @@ from itertools import chain
 from pathlib import Path
 from types import MappingProxyType
 
-import blosc
-import numpy as np
-
 from nxstacker.io.nxtomo.minimal import LINK_DATA, LINK_ROT_ANG, create_minimal
 from nxstacker.utils.logger import create_logger
 from nxstacker.utils.model import (
@@ -212,38 +209,6 @@ class TomoExpt:
                 # reach the first placeholder
                 break
         self._proj_dir = Path(proj_dir).resolve()
-
-    def _save_proj_to_dset(self, fh, proj_index, proj, angle):
-        use_direct_chunk = True
-        proj_dset = fh[self.proj_dset_path]
-        if use_direct_chunk:
-            # ensure it is contiguous
-            proj = np.ascontiguousarray(proj)
-
-            if self.compression_settings is None:
-                # no compression
-                saved = proj.tobytes()
-            else:
-                # blosc compression
-                ptr_proj = proj.__array_interface__["data"][0]
-                comopts = self.compression_settings.comopts
-                cname = self.compression_settings.compressor
-                saved = blosc.compress_ptr(
-                    ptr_proj,
-                    items=proj.size,
-                    typesize=proj.itemsize,
-                    clevel=comopts[4],
-                    shuffle=comopts[5],
-                    cname=cname,
-                )
-
-            proj_dset.id.write_direct_chunk((proj_index, 0, 0), saved)
-        else:
-            proj_dset = fh[self.proj_dset_path]
-            proj_dset[proj_index, :, :] = proj
-
-        rot_ang_dset = fh[self.rot_ang_dset_path]
-        rot_ang_dset[proj_index] = angle
 
     def _gather_raw_dir_from_proj_file(self):
         if self.num_projections != 0:

--- a/src/nxstacker/experiment/xrftomo.py
+++ b/src/nxstacker/experiment/xrftomo.py
@@ -7,7 +7,11 @@ import numpy as np
 from nxstacker.experiment.tomoexpt import TomoExpt
 from nxstacker.io.nxtomo.metadata import MetadataXRF
 from nxstacker.io.xrf.python_processing import XRFWindowFile
-from nxstacker.utils.io import file_has_paths
+from nxstacker.utils.io import (
+    file_has_paths,
+    pad2stack,
+    save_proj_to_h5,
+)
 from nxstacker.utils.logger import create_logger
 from nxstacker.utils.model import XRFTransitionList
 from nxstacker.utils.parse import quote_iterable, unique_or_raise
@@ -167,8 +171,16 @@ class XRFTomo(TomoExpt):
                     rot_ang = pty_file.id_angle
                     el_map = pty_file.elemental_map(transition)
 
-                    el_map = self._resize_proj(el_map, st_sh)
-                    self._save_proj_to_dset(f, k, el_map, rot_ang)
+                    el_map = pad2stack(el_map, st_sh)
+                    el_data = {
+                        "data": el_map,
+                        "key": self.proj_dset_path,
+                    }
+                    angle_data = {
+                        "data": rot_ang,
+                        "key": self.rot_ang_dset_path,
+                    }
+                    save_proj_to_h5(f, k, el_data, angle_data)
 
         self._nxtomo_output_files = nxtomo_flist
 

--- a/src/nxstacker/experiment/xrftomo.py
+++ b/src/nxstacker/experiment/xrftomo.py
@@ -43,7 +43,7 @@ class XRFTomo(TomoExpt):
         sort_by_angle=False,
         pad_to_max=True,
         compress=False,
-        skip_proj_file_check=True,
+        skip_proj_file_check=False,
         **kwargs,
     ):
         """Initialise the instance."""

--- a/src/nxstacker/parser/parser.py
+++ b/src/nxstacker/parser/parser.py
@@ -25,7 +25,7 @@ HELP_EXCLUDE_ANGLE = "rotation angle(s) that should be excluded from"
 HELP_SORT_BY_ANGLE = "sort the projections by their rotation angles"
 HELP_PAD_TO_MAX = "pad projection to the maximum size of the stack"
 HELP_COMPRESS = "compress the NXtomo file"
-HELP_VERIFY_PROJ_FILE = "check if the projection file is valid"
+HELP_SKIP_CHECK = "skip the validation of the projection file"
 HELP_SAVE_COMPLEX = "save the complex result from ptychography"
 HELP_SAVE_MODULUS = "save the modulus result from ptychography"
 HELP_SAVE_PHASE = "save the phase result from ptychography"
@@ -112,10 +112,10 @@ def _parser_common():
         "--compress", action="store_true", default=False, help=HELP_COMPRESS
     )
     parser.add_argument(
-        "--verify-proj-file",
-        action="store_false",
+        "--skip-check",
+        action="store_true",
         dest="skip_proj_file_check",
-        help=HELP_VERIFY_PROJ_FILE,
+        help=HELP_SKIP_CHECK,
     )
 
     return parser

--- a/src/nxstacker/tomojoin.py
+++ b/src/nxstacker/tomojoin.py
@@ -33,7 +33,7 @@ def tomojoin(
     compress=False,
     quiet=False,
     dry_run=False,
-    skip_proj_file_check=True,
+    skip_proj_file_check=False,
     **kwargs,
 ):
     """Combine projections to produce an NXtomo file.
@@ -105,7 +105,7 @@ def tomojoin(
         whether to skip the file check when adding an hdf5 to the list
         of projection files. Usually this is true when you are doing a
         typical stacking and sure no other hdf5 files are present in
-        proj_dir. Default to True.
+        proj_dir. Default to False.
     kwargs : dict, optional
         options for ptycho-tomography
 

--- a/src/nxstacker/utils/experiment.py
+++ b/src/nxstacker/utils/experiment.py
@@ -17,7 +17,7 @@ def select_tomo_expt(
     sort_by_angle=False,
     pad_to_max=True,
     compress=False,
-    skip_proj_file_check=True,
+    skip_proj_file_check=False,
     **kwargs,
 ):
     """Select the experiment for the projections.
@@ -68,7 +68,7 @@ def select_tomo_expt(
         whether to skip the file check when adding an hdf5 to the list
         of projection files. Usually this is true when you are doing a
         typical stacking and sure no other hdf5 files are present in
-        proj_dir. Default to True.
+        proj_dir. Default to False.
     kwargs : dict, optional
         optional arguments to different types of experiments
 

--- a/src/nxstacker/utils/io.py
+++ b/src/nxstacker/utils/io.py
@@ -3,6 +3,7 @@ import subprocess
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
+import blosc
 import h5py
 import numpy as np
 
@@ -238,3 +239,67 @@ def pad2stack(proj, stack_shape):
         final = proj
 
     return final
+
+
+def save_proj_to_h5(
+    fh, proj_index, proj_data, angle_data, compression_settings=None
+):
+    """Write projection and its rotation angle to an HDF5 file.
+
+    It uses direct chunk write.
+
+    Parameters
+    ----------
+    fh : h5py.File
+        the h5py file handler where the projection and rotation angle
+        will be saved to.
+    proj_index : int
+        the index of this projection.
+    proj_data : dict
+        a dictionary with keys 'data' and 'key', the projection to be
+        saved and the corresponding dataset key respectively.
+    angle_data : dict
+        a dictionary with keys 'data' and 'key', the rotation angle to
+        be saved and the corresponding dataset key respectively.
+    compression_settings : utils.model.CompressionBlosc, optional
+        the instance that encapsulates Blosc compression options.
+        Default to None, no compression.
+
+    Raises
+    ------
+    KeyError
+        if either 'proj_data' or 'angle_data' misses one of the
+        following keys: 'data', 'key'.
+
+    """
+    # raise KeyError directly, don't default to anything
+    proj = np.asarray(proj_data["data"])
+    proj_dset_key = proj_data["key"]
+    angle = float(angle_data["data"])
+    rot_ang_dset_key = angle_data["key"]
+
+    # ensure it is contiguous
+    proj = np.ascontiguousarray(proj)
+
+    if compression_settings is None:
+        # no compression
+        saved = proj.tobytes()
+    else:
+        # blosc compression
+        ptr_proj = proj.__array_interface__["data"][0]
+        comopts = compression_settings.comopts
+        cname = compression_settings.compressor
+        saved = blosc.compress_ptr(
+            ptr_proj,
+            items=proj.size,
+            typesize=proj.itemsize,
+            clevel=comopts[4],
+            shuffle=comopts[5],
+            cname=cname,
+        )
+
+    proj_dset = fh[proj_dset_key]
+    proj_dset.id.write_direct_chunk((proj_index, 0, 0), saved)
+
+    rot_ang_dset = fh[rot_ang_dset_key]
+    rot_ang_dset[proj_index] = angle

--- a/src/nxstacker/utils/io.py
+++ b/src/nxstacker/utils/io.py
@@ -200,6 +200,11 @@ def pad2stack(proj, stack_shape):
         the padded image, return the same image if they are of equal
         size.
 
+    Raises
+    ------
+    either the y or x dimension of the projection is larger than the
+    stack shape.
+
     """
     proj = np.asarray(proj)
     proj_y, proj_x = proj.shape

--- a/src/nxstacker/utils/resource.py
+++ b/src/nxstacker/utils/resource.py
@@ -1,0 +1,22 @@
+import os
+
+
+def num_cpus(capped_at=8):
+    """Return the capped number of available CPUs.
+
+    This is to prevent using all the available CPUs when this is
+    executed in an NX session, for example, while using more than 8 CPUs
+    does not gain much.
+
+    Parameters
+    ----------
+    capped_at : int, optional
+        the maximum number of CPUs to be used. Default to 8.
+
+    """
+    # from py3.13 there is a os.process_cpu_count function
+    # can switch over once <=py3.12 support is dropped
+    avail_cpus = len(os.sched_getaffinity(0))
+
+    # capped
+    return min(avail_cpus, capped_at)

--- a/src/nxstacker/utils/resource.py
+++ b/src/nxstacker/utils/resource.py
@@ -1,19 +1,21 @@
 import os
 
 
-def num_cpus(capped_at=8):
+def num_cpus(capped_at=32):
     """Return the capped number of available CPUs.
 
     This is to prevent using all the available CPUs when this is
-    executed in an NX session, for example, while using more than 8 CPUs
+    executed in an NX session, for example, while using more than 32 CPUs
     does not gain much.
 
     Parameters
     ----------
     capped_at : int, optional
-        the maximum number of CPUs to be used. Default to 8.
+        the maximum number of CPUs to be used. Default to 32.
 
     """
+    capped_at = max(capped_at, 1)
+
     # from py3.13 there is a os.process_cpu_count function
     # can switch over once <=py3.12 support is dropped
     avail_cpus = len(os.sched_getaffinity(0))

--- a/src/tests/utils/test_io.py
+++ b/src/tests/utils/test_io.py
@@ -1,6 +1,9 @@
 from pathlib import Path
 
-from nxstacker.utils.io import is_staging_area, top_level_dir
+import numpy as np
+import pytest
+
+from nxstacker.utils.io import is_staging_area, pad2stack, top_level_dir
 
 
 class TestTopLevelDir:
@@ -34,3 +37,26 @@ class TestIsStagingArea:
         input_dir = Path("/abc/dls/staging/dls/i99/data/2047/cm12345-1")
 
         assert not is_staging_area(input_dir)
+
+
+class TestPad2Stack:
+    def test_proj_smaller(self):
+        proj = np.arange(7 * 8).reshape(7, 8)
+        stack_shape = (3, 10, 11)
+        padded = pad2stack(proj, stack_shape)
+
+        assert padded.shape == (10, 11)
+
+    def test_proj_equal(self):
+        proj = np.arange(10 * 11).reshape(10, 11)
+        stack_shape = (3, 10, 11)
+        padded = pad2stack(proj, stack_shape)
+
+        assert padded.shape == (10, 11)
+
+    def test_proj_larger(self):
+        proj = np.arange(10 * 12).reshape(10, 12)
+        stack_shape = (3, 10, 11)
+
+        with pytest.raises(ValueError, match="larger"):
+            pad2stack(proj, stack_shape)

--- a/src/tests/utils/test_resource.py
+++ b/src/tests/utils/test_resource.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch
+
+from nxstacker.utils.resource import num_cpus
+
+
+class TestNumCpus:
+    @patch("nxstacker.utils.resource.os")
+    def test_below_capped(self, mock_os):
+        mock_os.sched_getaffinity.return_value = list(range(5))
+
+        assert num_cpus() == 5
+
+    @patch("nxstacker.utils.resource.os")
+    def test_above_capped(self, mock_os):
+        mock_os.sched_getaffinity.return_value = list(range(96))
+
+        assert num_cpus() == 32
+
+    @patch("nxstacker.utils.resource.os")
+    def test_custom_caps(self, mock_os):
+        mock_os.sched_getaffinity.return_value = list(range(8))
+
+        assert num_cpus(capped_at=4) == 4
+
+    @patch("nxstacker.utils.resource.os")
+    def test_capped_at_zero(self, mock_os):
+        mock_os.sched_getaffinity.return_value = list(range(8))
+
+        assert num_cpus(capped_at=0) == 1


### PR DESCRIPTION
Partly addresses #1.

This PR parallelise the stacking of projections in ptycho-tomo experiment by reading different projection files asynchronously, putting them in a queue and stack them to an HDF5 file as they become available.

Significant refactoring has been done to both allow serial and parallel cases. It switches to parallel stacking if more than 50 projections are to be stacked. On average it provides about 30% speed-up.

The writing to HDF5 is now by direct chunk write, however the observed improvement in speed is not significant. By changing the compressor from `zstd` to `blosclz`, the compression speed is improved significantly although the compression ratio is lower.

It changes the default of skipping projection file validation to `False` for safety.

Some tests are added when several methods are refactored.