### PR TITLE
Lower the number of capped CPUs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.2
+    rev: v0.12.3
     hooks:
       # Run the linter.
       - id: ruff
@@ -9,7 +9,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.42.0
+    rev: v0.45.0
     hooks:
     - id: markdownlint
 

--- a/README.md
+++ b/README.md
@@ -183,8 +183,9 @@ the current working directory is used.
 
 - *proj_file*
 
-the projection file with placeholder `%(scan)` from *include_scan*
-and `%(proj)` from *include_proj*. If it is `None`, it will search in
+the projection file with placeholder `%(scan)` deduced from *from_scan*,
+*scan_list* and *exclude_scan*, and `%(proj)` deduced from *from_proj*,
+*proj_list* and *exclude_proj*. If it is `None`, it will search in
 *proj_dir*.  If the name of the projection files follow a pattern, it is
 recommended to use this as it avoids going through files and directories when
 searching in *proj_dir*.

--- a/src/nxstacker/tomojoin.py
+++ b/src/nxstacker/tomojoin.py
@@ -52,8 +52,10 @@ def tomojoin(
         the directory where the projections are stored. If it is
         None, the current working directory is used. Default to None.
     proj_file : str or None
-        the projection file with placeholder %(scan) from include_scan
-        and %(proj) from include_proj. Default to None.
+        the projection file with placeholder %(scan) deduced from
+        'from_scan', 'scan_list' and 'exclude_scan', and %(proj) deduced
+        from 'from_proj', 'proj_list' and 'exclude_proj'. Default to
+        None.
     nxtomo_dir : pathlib.Path, str or None
         the directory where the NXtomo files will be saved. If it is
         None, the current working directory is used. Default to None.

--- a/src/nxstacker/utils/resource.py
+++ b/src/nxstacker/utils/resource.py
@@ -1,17 +1,17 @@
 import os
 
 
-def num_cpus(capped_at=32):
+def num_cpus(capped_at=8):
     """Return the capped number of available CPUs.
 
     This is to prevent using all the available CPUs when this is
-    executed in an NX session, for example, while using more than 32 CPUs
+    executed in an NX session, for example, while using more than 8 CPUs
     does not gain much.
 
     Parameters
     ----------
     capped_at : int, optional
-        the maximum number of CPUs to be used. Default to 32.
+        the maximum number of CPUs to be used. Default to 8.
 
     """
     capped_at = max(capped_at, 1)


### PR DESCRIPTION
This PR lowers the number of capped CPUs from 32 to 8, as in some instances 32 is still too many in an NX session.

Some docs string updates and pre-commit maintenance are also included.