### PR TITLE
Fix invalid semvar because of calendar versioning

### DIFF
--- a/.github/workflows/deploy_image.yml
+++ b/.github/workflows/deploy_image.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=semver,pattern={{version}}
+            type=match,pattern=v(.*),group=1
 
       - name: Build and push Docker image
         id: push

--- a/.github/workflows/deploy_image.yml
+++ b/.github/workflows/deploy_image.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           push: true
@@ -53,7 +53,7 @@ jobs:
             ${{ steps.meta.outputs.labels }}
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
           subject-digest: ${{ steps.push.outputs.digest }}


### PR DESCRIPTION
This PR fixes the issue about [invalid semvar in the workflow `deploy_image.yml`](https://github.com/DiamondLightSource/nxstacker/actions/runs/16574221224/job/46874303485#step:4:31) as this package uses calendar versioning.

@davehadley hopefully after this fix the workflow will work.